### PR TITLE
feat: remove hashed powerlink placeholders

### DIFF
--- a/sources/src/index.ts
+++ b/sources/src/index.ts
@@ -52,6 +52,14 @@ setInterval(() => {
     AdContainers = AdContainers.filter(AdContainer => !/\[[0-9]+\] .+/.test(AdContainer.innerText))
 
     AdContainers.forEach(Ele => Ele.remove())
+
+    let AdPlaceholders = Array.from(document.querySelectorAll('div[class]'))
+      .filter((Ele): Ele is HTMLElement => Ele instanceof HTMLElement)
+      .filter(Ele => /^w[0-9a-zA-Z]{7}$/.test(Ele.className))
+      .filter(Ele => Ele.innerText.trim().length === 0)
+      .filter(Ele => Ele.childElementCount > 0)
+
+    AdPlaceholders.forEach(Ele => Ele.remove())
   }
 }, 1000)
 


### PR DESCRIPTION
## Summary
- remove hashed PowerLink placeholders that left grey backgrounds
- simplify placeholder detection using `childElementCount`

## Testing
- `pnpm lint` *(fails: Definition for rule '@typescript-eslint/no-unsafe-function-type' was not found)*
- `npx tsc --noEmit`
- `npx eslint sources --ext .ts`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68aef4cc2414832cb241a623d866fd38